### PR TITLE
Adding set_gql/3 feature

### DIFF
--- a/lib/gql_case.ex
+++ b/lib/gql_case.ex
@@ -67,6 +67,33 @@ defmodule Wormwood.GQLCase do
   @doc """
   Call this macro in the module where you want to query using a static string as your query.
 
+  It takes 3 arguments, the first is the query_name that you want to query, the second is your Absinthe schema module and
+  the third is a string of a GQL query or mutation.
+
+  ```elixir
+   defmodule MyCoolApplication.MyModule do
+    set_gql :my_query, MyCoolApplication.MyAbsintheSchema, "query { some { cool { gql { id } }}}"
+    # ...
+  ```
+
+  After you define the query name at up code, you can call the query with
+  ```elixir
+  result = query_gql_by(:my_query, variables: %{}, context: %{})
+  {:ok, query_data} = result
+  ```
+  """
+  defmacro set_gql(query_name, schema, query_string) when is_atom(query_name) do
+    quote do
+      document = GQLLoader.load_string!(unquote(query_string))
+      Module.put_attribute(unquote(__CALLER__.module), :_wormwood_gql_schema, unquote(schema))
+      Module.register_attribute(unquote(__CALLER__.module), unquote(query_name), persist: true)
+      Module.put_attribute(unquote(__CALLER__.module), unquote(query_name), document)
+    end
+  end
+
+  @doc """
+  Call this macro in the module where you want to query using a static string as your query.
+
   It takes 2 arguments, the first is your Absinthe schema module, the second is a string of a GQL query or mutation.
   This still supports imports, they will be resolved from the current working directory. (Most likely the top level of your app)
 

--- a/test/multiple_gql_case_test.exs
+++ b/test/multiple_gql_case_test.exs
@@ -2,16 +2,44 @@ defmodule Wormwood.Test.MultipleGQLCaseTest do
   use ExUnit.Case
   use Wormwood.GQLCase
 
-  load_gql(:get_users, Wormwood.Examples.Schema, "assets/GetUsers.gql")
-  load_gql(:get_messages, Wormwood.Examples.Schema, "assets/GetMessages.gql")
+  load_gql(:get_users_using_load, Wormwood.Examples.Schema, "assets/GetUsers.gql")
+  load_gql(:get_messages_using_load, Wormwood.Examples.Schema, "assets/GetMessages.gql")
 
-  test "Should execute a valid query of get_users" do
-    result = query_gql_by(:get_users)
+  set_gql(:get_users_using_set, Wormwood.Examples.Schema, """
+  #import "assets/UserFields.frag.gql"
+  query {
+    Users {
+      ...UserFields
+    }
+  }
+  """)
+
+  set_gql(:get_messages_using_set, Wormwood.Examples.Schema, """
+  #import "assets/MessageFields.frag.gql"
+  query {
+    Messages {
+      ...MessageFields
+    }
+  }
+  """)
+
+  test "Should execute a valid query of get_users_using_load" do
+    result = query_gql_by(:get_users_using_load)
     assert {:ok, _query_data} = result
   end
 
-  test "Should execute a valid query of get_messages" do
-    result = query_gql_by(:get_messages)
+  test "Should execute a valid query of get_messages_using_load" do
+    result = query_gql_by(:get_messages_using_load)
+    assert {:ok, _query_data} = result
+  end
+
+  test "Should execute a valid query of get_users_using_set" do
+    result = query_gql_by(:get_users_using_set)
+    assert {:ok, _query_data} = result
+  end
+
+  test "Should execute a valid query of get_messages_using_set" do
+    result = query_gql_by(:get_messages_using_set)
     assert {:ok, _query_data} = result
   end
 end


### PR DESCRIPTION
In order to use set_gql multiples times in the same module, was added the method ```set_gql/3```.

The method ```set_gql/3``` has the same behaviour than ```load_gql/3``` the difference between both is that
```set_gql/3``` use static string query instead of import throw the file_path.

Close #19 